### PR TITLE
Update docker file to allow build with current version of packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+# Prevent tzdata config questions
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y sudo libsm6 libxext6 libxrender-dev libv4l-dev python3.6 python3-pip python3.6-dev git && \
+    apt-get install -y sudo libsm6 libxext6 libxrender-dev libv4l-dev python3.8 python3-pip python3.8-dev git libgl1-mesa-glx libglib2.0-0 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy
-opencv-python
-Pillow
-imutils
+numpy==1.19.4
+opencv-python==4.4.0.46
+Pillow==8.0.1
+imutils==0.5.3
 git+https://github.com/aspotton/python3-v4l2.git


### PR DESCRIPTION
I got an error during build of the docker image with the original code since OpenCV could not find “skbuild”. The solution suggested [here](https://stackoverflow.com/questions/63448467/installing-opencv-fails-because-it-cannot-find-skbuild) was to update `pip` which I did by updating the base system of the docker image to Ubuntu 20.04 (and then fixing the newly missing requirements).
I also added specific package versions to `requirements.txt` to enhance reproducibility